### PR TITLE
Throw error if json encoding fails

### DIFF
--- a/lib/GetStream/Stream/Feed.php
+++ b/lib/GetStream/Stream/Feed.php
@@ -78,6 +78,9 @@ class Feed extends BaseFeed
 
         if ($method === 'POST' || $method === 'POST') {
             $json_data = json_encode($data);
+            if (!$json_data) {
+                throw new StreamWrongInputException("json_encode failed:".json_last_error());
+            }
             $request->setBody(Stream::factory($json_data));
         }
 


### PR DESCRIPTION
This would help debugging.

Ran into an issue where the content we were trying to encode was not UTF-8 encoded. This lead to this mysterious error...

```
PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'Invalid resource type: boolean'
```

Be warned that using json_last_error() requires PHP > 5.5.0 although it's easy to roll your own http://php.net/manual/en/function.json-last-error-msg.php#113243
