### PR TITLE
Change Composer Requirements to be less restrictive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "4.3.*",
+        "phpunit/phpunit": "^4.3",
         "satooshi/php-coveralls": "dev-master"
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "6.0.*",
-        "firebase/php-jwt": "2.1.*",
+        "guzzlehttp/guzzle": "^6.0",
+        "firebase/php-jwt": "^2.1",
         "99designs/http-signatures": ">=1.1.0 <3.0.0"
     },
     "autoload": {


### PR DESCRIPTION
Move to using the caret operator as this is recommended for composer libraries and ensures maximum compatibility.

Resolves #25 