### PR TITLE
Make local port used configurable via environment varible

### DIFF
--- a/lib/GetStream/Stream/Client.php
+++ b/lib/GetStream/Stream/Client.php
@@ -141,8 +141,9 @@ class Client
      */
     public function getBaseUrl()
     {
-        if (getenv('LOCAL')) {
-            $baseUrl = 'http://localhost:8000/api';
+        $localPort = getenv('GET_STREAM_LOCAL_PORT');
+        if ($localPort) {
+            $baseUrl = "http://localhost:$localPort/api";
         } else {
             if ($this->location) {
                 $subdomain = "{$this->location}-api";


### PR DESCRIPTION
Currently the port used for redirection when testing with a local instance is hardcoded to be port 8000. To integrate with our current test environment we need this port number to be configurable. I thought it would be a good idea to contribute this change back to the upstream code.

The environment variable name is also changed from the non-descript "LOCAL" (that could clash with other environment variables and does not tell where this env. var comes from or where it is used) to the more descriptive name "GET_STREAM_LOCAL_PORT". When you see that environment variable in the web server settings you will immediately know that it got something to do with GetStream. 