### PR TITLE
Make local port used configurable via environment variable, take 2

### DIFF
--- a/lib/GetStream/Stream/Client.php
+++ b/lib/GetStream/Stream/Client.php
@@ -141,8 +141,9 @@ class Client
      */
     public function getBaseUrl()
     {
-        if (getenv('LOCAL')) {
-            $baseUrl = 'http://localhost:8000/api';
+        $localPort = getenv('GET_STREAM_LOCAL_PORT');
+        if ($localPort) {
+            $baseUrl = "http://localhost:$localPort/api";
         } else {
             if ($this->location) {
                 $subdomain = "{$this->location}-api";


### PR DESCRIPTION
This PR is about making the port number used for running the api locally configurable.

It is desirable to not have this port number to be hardcoded as port 8000.