### PR TITLE
removing port 82 from qa environment

### DIFF
--- a/lib/GetStream/Stream/Client.php
+++ b/lib/GetStream/Stream/Client.php
@@ -152,7 +152,7 @@ class Client
             if ($this->location) {
                 $subdomain = "{$this->location}-api";
                 if ($this->location == 'qa') {
-                    $api_endpoint = 'getstream.io:82/api';
+                    $api_endpoint = 'getstream.io/api';
                     $this->setProtocol('http');
                 }
             } else {

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -17,7 +17,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client = new Client('key', 'secret');
         $client->setLocation('qa');
         $url = $client->buildRequestUrl('x');
-        $this->assertSame($url, 'http://qa-api.getstream.io:82/api/v1.0/x');
+        $this->assertSame($url, 'http://qa-api.getstream.io/api/v1.0/x');
 
         $client = new Client('key', 'secret', $api_version='1234', $location='asdfg');
         $url = $client->buildRequestUrl('y');


### PR DESCRIPTION
## Summary:
removed port 82 from qa environment

## PR - Merge Checklist:
-- Verify:
- [x] ALL tests have passed

## Risks:
None, change only affects Stream staff running tests on PHP library

## Rollback:
git revert
