### PR TITLE
Update activities with empty array failed

### DIFF
--- a/lib/GetStream/Stream/ActivityUpdateOperation.php
+++ b/lib/GetStream/Stream/ActivityUpdateOperation.php
@@ -29,6 +29,10 @@ class ActivityUpdateOperation extends Feed
 
     public function updateActivities($activities)
     {
+        if (empty($activities)) {
+            return;
+        }
+
         $data = [
             'activities' => $activities
         ];

--- a/lib/GetStream/Stream/ActivityUpdateOperation.php
+++ b/lib/GetStream/Stream/ActivityUpdateOperation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GetStream\Stream;
 
 use Exception;
@@ -7,10 +8,8 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\CurlHandler;
 
-
 class ActivityUpdateOperation extends Feed
 {
-
     protected $token;
 
     public function __construct($client, $api_key, $token)

--- a/lib/GetStream/Stream/Client.php
+++ b/lib/GetStream/Stream/Client.php
@@ -175,6 +175,10 @@ class Client
 
     public function updateActivities($activities)
     {
+        if (empty($activities)) {
+            return;
+        }
+
         $token = $this->signer->jwtScopeToken('*', 'activities', '*');
         $activityUpdateOp = new ActivityUpdateOperation($this, $this->api_key, $token);
         return $activityUpdateOp->updateActivities($activities);

--- a/tests/integration/FeedTest.php
+++ b/tests/integration/FeedTest.php
@@ -31,6 +31,9 @@ function gen_uuid() {
 
 class FeedTest extends TestCase
 {
+    /**
+     * @var Client
+     */
     protected $client;
     protected $user1;
     protected $aggregated2;
@@ -595,5 +598,10 @@ class FeedTest extends TestCase
 
         $response = $this->client->feed('flat', $target2)->getActivities();
         $this->assertCount(1, $response['results']);
+    }
+
+    public function testUpdateActivitiesWithZeroActivitiesShouldNotFail()
+    {
+        $this->client->updateActivities([]);
     }
 }


### PR DESCRIPTION
### Changed

- Silently return nothing when meaningless input is given on `Client::updateActivities` method.

---
should fix #40