### PR TITLE
Fix automatic client version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.5",
         "guzzlehttp/guzzle": "^6.0",
         "firebase/php-jwt": "~3.0|~4.0|~5.0",
-        "99designs/http-signatures": ">=1.1.0 <3.0.0"
+        "99designs/http-signatures": ">=1.1.0 <3.0.0",
+        "ocramius/package-versions": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.3",

--- a/lib/GetStream/Stream/Client.php
+++ b/lib/GetStream/Stream/Client.php
@@ -2,8 +2,7 @@
 namespace GetStream\Stream;
 
 use Exception;
-
-const VERSION = '2.5.2';
+use PackageVersions\Versions;
 
 class Client
 {
@@ -45,6 +44,11 @@ class Client
     public $timeout;
 
     /**
+     * @var string
+     */
+    private $version;
+
+    /**
      * @param string $api_key
      * @param string $api_secret
      * @param string $api_version
@@ -59,6 +63,16 @@ class Client
         $this->timeout = $timeout;
         $this->location = $location;
         $this->protocol = 'https';
+
+        // Get the currently installed version (something like 2.4.0@{commithash}). Only the first part is needed.
+        list($version,) = explode('@', Versions::getVersion('get-stream/stream'));
+
+        // In CI, use something else.
+        if ($version === '9999999-dev') {
+            $version = 'dev';
+        }
+
+        $this->version = $version;
     }
 
     /**
@@ -200,4 +214,11 @@ class Client
         return $analytics->createRedirectUrl($targetUrl, $events);
     }
 
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
 }

--- a/lib/GetStream/Stream/Client.php
+++ b/lib/GetStream/Stream/Client.php
@@ -67,7 +67,7 @@ class Client
         // Get the currently installed version (something like 2.4.0@{commithash}). Only the first part is needed.
         list($version,) = explode('@', Versions::getVersion('get-stream/stream'));
 
-        // In CI, use something else.
+        // In CI or in development, use something else.
         if ($version === '9999999-dev') {
             $version = 'dev';
         }

--- a/lib/GetStream/Stream/Feed.php
+++ b/lib/GetStream/Stream/Feed.php
@@ -57,11 +57,12 @@ class Feed extends BaseFeed
     protected function getHttpRequestHeaders($resource, $action)
     {
         $token = $this->client->createFeedJWTToken($this, $resource, $action);
+
         return [
             'Authorization'     => $token,
             'Content-Type'      => 'application/json',
             'stream-auth-type'  => 'jwt',
-            'X-Stream-Client'   => 'stream-php-client-' . VERSION
+            'X-Stream-Client'   => 'stream-php-client-' . $this->client->getVersion(),
         ];
     }
 


### PR DESCRIPTION
Turns out we've been forgetting to bump the constant since v2.2.2 and all incoming calls had a 2.2.2 header, regardless if the client was newer or not.

This should automate it.