### PR TITLE
Accept gzip responses

### DIFF
--- a/lib/GetStream/Stream/Feed.php
+++ b/lib/GetStream/Stream/Feed.php
@@ -41,7 +41,8 @@ class Feed extends BaseFeed
         return new GuzzleClient([
             'base_uri' => $this->client->getBaseUrl(),
             'timeout' => $this->client->timeout,
-            'handler' => $handler
+            'handler' => $handler,
+            'headers' => ['Accept-Encoding' => 'gzip'],
         ]);
     }
 


### PR DESCRIPTION
### Changed

- Sending accept-encoding header to request the server to respond with gzipped response bodies.

---

Ref: AC-14