### PR TITLE
Fix a potential undefined constant reference

### DIFF
--- a/lib/GetStream/Stream/Client.php
+++ b/lib/GetStream/Stream/Client.php
@@ -4,11 +4,11 @@ namespace GetStream\Stream;
 use DateTime;
 use Exception;
 
-const VERSION = '4.1.0';
-
 class Client implements ClientInterface
 {
-    const API_ENDPOINT = 'stream-io-api.com/api';
+    public const VERSION = '4.1.0';
+
+    public const API_ENDPOINT = 'stream-io-api.com/api';
 
     /**
      * @var string

--- a/lib/GetStream/Stream/Collections.php
+++ b/lib/GetStream/Stream/Collections.php
@@ -202,7 +202,7 @@ class Collections
                     ->withAddedHeader('Authorization', $token)
                     ->withAddedHeader('Stream-Auth-Type', 'jwt')
                     ->withAddedHeader('Content-Type', 'application/json')
-                    ->withAddedHeader('X-Stream-Client', 'stream-php-client-' . VERSION);
+                    ->withAddedHeader('X-Stream-Client', 'stream-php-client-' . Client::VERSION);
 
                 // Add a api_key query param.
                 $queryParams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());

--- a/lib/GetStream/Stream/Feed.php
+++ b/lib/GetStream/Stream/Feed.php
@@ -64,7 +64,7 @@ class Feed extends BaseFeed implements FeedInterface
             'Authorization' => $token,
             'Content-Type' => 'application/json',
             'stream-auth-type' => 'jwt',
-            'X-Stream-Client' => 'stream-php-client-' . VERSION,
+            'X-Stream-Client' => 'stream-php-client-' . Client::VERSION,
         ];
     }
 

--- a/lib/GetStream/Stream/Personalization.php
+++ b/lib/GetStream/Stream/Personalization.php
@@ -124,7 +124,7 @@ class Personalization
                     ->withAddedHeader('Authorization', $token)
                     ->withAddedHeader('Stream-Auth-Type', 'jwt')
                     ->withAddedHeader('Content-Type', 'application/json')
-                    ->withAddedHeader('X-Stream-Client', 'stream-php-client-' . VERSION);
+                    ->withAddedHeader('X-Stream-Client', 'stream-php-client-' . Client::VERSION);
 
                 return $handler($request, $options);
             };

--- a/lib/GetStream/Stream/Reactions.php
+++ b/lib/GetStream/Stream/Reactions.php
@@ -221,7 +221,7 @@ class Reactions
                     ->withAddedHeader('Authorization', $token)
                     ->withAddedHeader('Stream-Auth-Type', 'jwt')
                     ->withAddedHeader('Content-Type', 'application/json')
-                    ->withAddedHeader('X-Stream-Client', 'stream-php-client-' . VERSION);
+                    ->withAddedHeader('X-Stream-Client', 'stream-php-client-' . Client::VERSION);
 
                 // Add a api_key query param.
                 $queryParams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());

--- a/lib/GetStream/Stream/Users.php
+++ b/lib/GetStream/Stream/Users.php
@@ -160,7 +160,7 @@ class Users
                     ->withAddedHeader('Authorization', $token)
                     ->withAddedHeader('Stream-Auth-Type', 'jwt')
                     ->withAddedHeader('Content-Type', 'application/json')
-                    ->withAddedHeader('X-Stream-Client', 'stream-php-client-' . VERSION);
+                    ->withAddedHeader('X-Stream-Client', 'stream-php-client-' . Client::VERSION);
 
                 // Add a api_key query param.
                 $queryParams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());


### PR DESCRIPTION
There's a chance of the `VERSION` constant being undefined if a file that uses it is loaded before the file with `GetStream\Stream\Client`. In PHP 7.4 results in an error exception being thrown. We actually didn't experience this error until yesterday, so by sheer luck the files have always been loaded in the right order.

This PR moves the constant into the Client class (and marks both constants explicitly as being public as it's good practice to do so) and references this class constant explicitly in the other files.