### PR TITLE
Fix wrong type docblock

### DIFF
--- a/lib/GetStream/Stream/BaseFeed.php
+++ b/lib/GetStream/Stream/BaseFeed.php
@@ -178,7 +178,7 @@ class BaseFeed implements BaseFeedInterface
     }
 
     /**
-     * @param int $activity_id
+     * @param string $activity_id
      * @param bool $foreign_id
      * @return mixed
      *

--- a/lib/GetStream/Stream/BaseFeedInterface.php
+++ b/lib/GetStream/Stream/BaseFeedInterface.php
@@ -67,7 +67,7 @@ interface BaseFeedInterface
     public function addActivities($activities);
 
     /**
-     * @param int $activity_id
+     * @param string $activity_id
      * @param bool $foreign_id
      * @return mixed
      *


### PR DESCRIPTION
Hello,

While working on an implementation of activity removal, my static analyzer found a false positive issue.
When calling `removeActivity` you can pass an id that is the id of the activity, of the foreign id (if the second parameter is set to true)

Both are strings:

1. Activity Id: cf documentation https://getstream.io/docs/adding_activities/?language=js
<img width="895" alt="Screenshot 2021-01-26 at 14 48 53" src="https://user-images.githubusercontent.com/3217330/105853112-9f517f80-5fe5-11eb-9666-8b4e8f333e78.png">

2. Activity Foreign Id: https://getstream.io/docs/adding_activities/?language=js#fields
<img width="869" alt="Screenshot 2021-01-26 at 14 48 28" src="https://user-images.githubusercontent.com/3217330/105853058-8fd23680-5fe5-11eb-9308-bf35739f17b0.png">
